### PR TITLE
support uint32 segmentation masks

### DIFF
--- a/pyramid_assemble.py
+++ b/pyramid_assemble.py
@@ -239,14 +239,19 @@ def main():
 
         print()
 
-    if dtype == np.uint32 and is_mask:
-        ome_dtype = 'uint32'
+    if dtype == np.uint32:
+        if is_mask:
+            ome_dtype = 'uint32'
+        else:
+            print("uint32 images are only supported in --mask mode. Please contact the authors if you need support for intensity-based uint32 images.")
+            sys.exit(1)
     elif dtype == np.uint16:
         ome_dtype = 'uint16'
     elif dtype == np.uint8:
         ome_dtype = 'uint8'
     else:
-        raise ValueError("can't handle dtype: %s" % dtype)
+        print("can't handle dtype: %s" % dtype)
+        sys.exit(1)
 
     xml = construct_xml(
         os.path.basename(out_path), shapes, num_channels, ome_dtype, args.pixel_size

--- a/pyramid_assemble.py
+++ b/pyramid_assemble.py
@@ -32,7 +32,7 @@ def preduce(coords, img_in, img_out, is_mask):
     else:
         tile = skimage.img_as_float32(img_in[iy1:iy2, ix1:ix2])
         tile = skimage.transform.downscale_local_mean(tile, (2, 2))
-    tile = dtype_convert(tile, img_out.dtype)
+        tile = dtype_convert(tile, img_out.dtype)
     img_out[oy1:oy2, ox1:ox2] = tile
 
 

--- a/pyramid_assemble.py
+++ b/pyramid_assemble.py
@@ -47,16 +47,8 @@ def format_shape(shape):
     return "%dx%d" % (shape[1], shape[0])
 
 
-def construct_xml(filename, shapes, num_channels, dtype, pixel_size=1):
+def construct_xml(filename, shapes, num_channels, ome_dtype, pixel_size=1):
     img_uuid = uuid.uuid4().urn
-    if dtype == np.uint32:
-        ome_dtype = 'uint32'
-    elif dtype == np.uint16:
-        ome_dtype = 'uint16'
-    elif dtype == np.uint8:
-        ome_dtype = 'uint8'
-    else:
-        raise ValueError("can't handle dtype: %s" % dtype)
     ifd = 0
     xml = io.StringIO()
     xml.write(u'<?xml version="1.0" encoding="UTF-8"?>')
@@ -153,7 +145,7 @@ def main():
     )
     parser.add_argument(
         "--mask", action="store_true", default=False,
-        help="will downsample without averaging pixels if true",
+        help="adjust processing for label mask or binary mask images (currently just switch to nearest-neighbor downsampling)",
     )
     args = parser.parse_args()
     in_paths = args.in_paths
@@ -247,8 +239,17 @@ def main():
 
         print()
 
+    if dtype == np.uint32 and is_mask:
+        ome_dtype = 'uint32'
+    elif dtype == np.uint16:
+        ome_dtype = 'uint16'
+    elif dtype == np.uint8:
+        ome_dtype = 'uint8'
+    else:
+        raise ValueError("can't handle dtype: %s" % dtype)
+
     xml = construct_xml(
-        os.path.basename(out_path), shapes, num_channels, dtype, args.pixel_size
+        os.path.basename(out_path), shapes, num_channels, ome_dtype, args.pixel_size
     )
     patch_ometiff_xml(out_path, xml)
 


### PR DESCRIPTION
I've modified `pyramid_assemble.py` to allow downsampling by skipping every other pixel when the `--mask` flag is passed to the command line. I also allowed the construction of xml files for the 32-bit integers that are typically found in segmentation masks. 

So far, this PR does not adequately handle the case of a 32-bit image without the `--mask` flag passed. The `preduce` function would still call `skimage.img_as_float32` on a 32-bit non-mask tile, but that would result in inexact integers for values above `2^24`. The most obvious solution would be to detect the dtype in `preduce` and call `skimage.img_as_float64` if the non-mask tile is a 32-bit unsigned integer. 