### PR TITLE
fix: handle situation when there is only one channel

### DIFF
--- a/pyramid_assemble.py
+++ b/pyramid_assemble.py
@@ -194,7 +194,10 @@ def main():
 
         def tile(coords):
             c, j, i = coords
-            tile = zimg[c, ts * j : ts * (j + 1), ts * i : ts * (i + 1)]
+            if len(zimg.shape) == 2:
+                tile = zimg[ts * j : ts * (j + 1), ts * i : ts * (i + 1)]
+            elif len(zimg.shape) == 3:
+                tile = zimg[c, ts * j : ts * (j + 1), ts * i : ts * (i + 1)]
             tile = skimage.transform.downscale_local_mean(tile, (2, 2))
             tile = np.round(tile).astype(dtype)
             return tile


### PR DESCRIPTION
Hi, thanks for this useful tool! 

I encountered an error when I tried to generate a pyramidal ome.tiff when there was only one channel in my image. 

```
Scanning input images
    file 1
        path: test.tiff
        properties: shape=(971, 1142) dtype=uint8

Pyramid level sizes:
    level 1: 1142 x 971 (original size)
    level 2: 571 x 486

Writing level 1: 1142 x 971
    channel 1

Resizing image for level 2: 571 x 486
Traceback (most recent call last):
  File "/mnt/nfs/home/wenruiwu/projects/ome-tiff-pyramid-tools/pyramid_assemble.py", line 250, in <module>
    main()
  File "/mnt/nfs/home/wenruiwu/projects/ome-tiff-pyramid-tools/pyramid_assemble.py", line 237, in main
    writer.write(
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/tifffile/tifffile.py", line 3269, in write
    iteritem, dataiter = peek_iterator(dataiter)
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/tifffile/tifffile.py", line 23685, in peek_iterator
    first = next(iterator)
  File "/mnt/nfs/home/wenruiwu/projects/ome-tiff-pyramid-tools/pyramid_assemble.py", line 204, in tiles
    yield from pool.map(tile, coords)
  File "/opt/miniforge3/envs/valis/lib/python3.10/concurrent/futures/_base.py", line 621, in result_iterator
    yield _result_or_cancel(fs.pop())
  File "/opt/miniforge3/envs/valis/lib/python3.10/concurrent/futures/_base.py", line 319, in _result_or_cancel
    return fut.result(timeout)
  File "/opt/miniforge3/envs/valis/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/opt/miniforge3/envs/valis/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/opt/miniforge3/envs/valis/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/mnt/nfs/home/wenruiwu/projects/ome-tiff-pyramid-tools/pyramid_assemble.py", line 197, in tile
    tile = zimg[c, ts * j : ts * (j + 1), ts * i : ts * (i + 1)]
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/zarr/core.py", line 797, in __getitem__
    result = self.get_basic_selection(pure_selection, fields=fields)
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/zarr/core.py", line 923, in get_basic_selection
    return self._get_basic_selection_nd(selection=selection, out=out, fields=fields)
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/zarr/core.py", line 963, in _get_basic_selection_nd
    indexer = BasicIndexer(selection, self)
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/zarr/indexing.py", line 330, in __init__
    selection = replace_ellipsis(selection, array._shape)
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/zarr/indexing.py", line 268, in replace_ellipsis
    check_selection_length(selection, shape)
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/zarr/indexing.py", line 233, in check_selection_length
    err_too_many_indices(selection, shape)
  File "/opt/miniforge3/envs/valis/lib/python3.10/site-packages/zarr/errors.py", line 70, in err_too_many_indices
    raise IndexError(f"too many indices for array; expected {len(shape)}, got {len(selection)}")
IndexError: too many indices for array; expected 2, got 3
```

My zarr version is 2.18.3. The reason of this bug is that the shape of `zimg` is (h, w), instead of (c, h, w), when my image has only one channel. So I modifed `pyramid_assemble.py` to handle this situation. 
